### PR TITLE
Some type annotations and .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{ts,tsx}]
+indent_style = tab
+indent_size = 4
+
+[{package.json}]
+indent_style = space
+indent_size = 2

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*   text eol=lf

--- a/src/components/Editor/Fields.tsx
+++ b/src/components/Editor/Fields.tsx
@@ -1,6 +1,7 @@
 import * as  React from 'react';
 import { connect } from 'react-redux';
 
+import Action 		 from 'state/action';
 import collapseField from 'state/collapseField';
 import expandField   from 'state/expandField';
 import setPath       from 'state/setPath';
@@ -35,17 +36,17 @@ const mapFieldIdsToTreeItems = (
 		});
 };
 
-const mapStateToProps = ( state: { doc: Doc, ui: DocUI }) => {
+const mapStateToProps = ( state: { doc: Doc, ui: DocUI } ) => {
 	return {
 		items: mapFieldIdsToTreeItems( state.doc.rootFields, state.doc.fields, state.ui.expandedFields ),
 	};
 };
 
-const mapDispatchToProps = ( dispatch: any ) => {
+const mapDispatchToProps = ( dispatch: (action: Action) => void ): Partial<TreeProps> => {
 	return {
-		onExpandItem:    ( item: any ) => dispatch( expandField(   item.id )),
-		onCollapseItem:  ( item: any ) => dispatch( collapseField( item.id )),
-		onCreateButtons: ( item: any ) => <button
+		onExpandItem:    ( item ) => dispatch( expandField(   item.id )),
+		onCollapseItem:  ( item ) => dispatch( collapseField( item.id )),
+		onCreateButtons: ( item ) => <button
 			onClick={ ev => {
 				dispatch( setPath( item.path ));
 				ev.stopPropagation();

--- a/src/components/Editor/FormulaEditor/FunctionNode.tsx
+++ b/src/components/Editor/FormulaEditor/FunctionNode.tsx
@@ -2,7 +2,9 @@ import * as React from 'react';
 import { DragSource, DragSourceMonitor, DragSourceSpec } from 'react-dnd';
 import { connect as reduxConnect } from 'react-redux';
 
+import Action from 'state/action';
 import moveNode from 'state/moveNode';
+import { State } from 'state/reducers';
 
 import { Node, NodeMap } from 'data/doc';
 import Fxn from 'data/fxn';
@@ -18,16 +20,17 @@ export interface FunctionNodeProps extends React.Props<FunctionNode> {
 	id: number;
 }
 
-//------------------------------------------------------------------------------
-
-interface WrappedFunctionNodeProps extends FunctionNodeProps {
-	nodes: NodeMap;
+export interface FunctionNodeDispatchers {
 	onMove?: ( id: number, position: Position ) => void;
-	isDragging: boolean;
-	connectDragSource: ( component: JSX.Element ) => JSX.Element;
 }
 
 //------------------------------------------------------------------------------
+
+interface WrappedFunctionNodeProps extends FunctionNodeProps, FunctionNodeDispatchers {
+	nodes: NodeMap;
+	isDragging: boolean;
+	connectDragSource: <P> ( component: React.ReactElement<P> ) => React.ReactElement<P>;
+}
 
 const cardSource: DragSourceSpec<WrappedFunctionNodeProps> = {
 	beginDrag: ( props: WrappedFunctionNodeProps ): ( Node | {} ) => props.nodes.get( props.id ) || {},
@@ -96,10 +99,10 @@ class FunctionNode extends React.PureComponent<WrappedFunctionNodeProps, {}> {
 //------------------------------------------------------------------------------
 
 export default reduxConnect<{}, {}, FunctionNodeProps>(
-	state => ({
+	(state: State): Partial<WrappedFunctionNodeProps> => ({
 		nodes: state.doc.nodes,
 	}),
-	dispatch => ({
-		onMove: ( id: number, position: Position ) => dispatch( moveNode( id, position )),
+	( dispatch: (action: Action) => void ): FunctionNodeDispatchers => ({
+		onMove: ( id, position ) => dispatch( moveNode( id, position )),
 	}),
 )( FunctionNode );

--- a/src/components/Editor/FormulaEditor/FunctionNode.tsx
+++ b/src/components/Editor/FormulaEditor/FunctionNode.tsx
@@ -22,9 +22,9 @@ export interface FunctionNodeProps extends React.Props<FunctionNode> {
 
 interface WrappedFunctionNodeProps extends FunctionNodeProps {
 	nodes: NodeMap;
-	onMove: (id: number, position: Position) => void;
+	onMove?: ( id: number, position: Position ) => void;
 	isDragging: boolean;
-	connectDragSource: ( component: any ) => any;
+	connectDragSource: ( component: JSX.Element ) => JSX.Element;
 }
 
 //------------------------------------------------------------------------------
@@ -33,7 +33,7 @@ const cardSource: DragSourceSpec<WrappedFunctionNodeProps> = {
 	beginDrag: ( props: WrappedFunctionNodeProps ): ( Node | {} ) => props.nodes.get( props.id ) || {},
 	endDrag:   ( props: WrappedFunctionNodeProps, monitor: DragSourceMonitor, component ) => {
 		if ( monitor.didDrop() ) {
-			if (!props.nodes || !props.onMove) {
+			if (props.nodes.size === 0 || !props.onMove) {
 				return;
 			}
 
@@ -59,7 +59,7 @@ const cardSource: DragSourceSpec<WrappedFunctionNodeProps> = {
 	isDragging: monitor.isDragging(),
 }))
 class FunctionNode extends React.PureComponent<WrappedFunctionNodeProps, {}> {
-	public render() {
+	public render(): JSX.Element | null {
 		const { connectDragSource, isDragging, id, nodes } = this.props;
 
 		const { label, fxn, position } = nodes.get( id ) as Node;

--- a/src/components/Editor/FormulaEditor/index.tsx
+++ b/src/components/Editor/FormulaEditor/index.tsx
@@ -6,7 +6,9 @@ import HTML5Backend from 'react-dnd-html5-backend';
 
 import { Field, FieldMap } from 'data/doc';
 
+import Action  from 'state/action';
 import addNode from 'state/addNode';
+import {State} from 'state/reducers';
 import setPath from 'state/setPath';
 
 import FAB from 'components/common/FAB';
@@ -64,12 +66,12 @@ class FormulaEditor extends React.PureComponent<WrappedFormulaEditorProps, {}> {
 }
 
 const ConnectedNodeEditor = connect<{}, {}, FormulaEditorProps>(
-	state => ({
+	( state: State ): Partial<WrappedFormulaEditorProps> => ({
 		path:      state.path,
-		rootField: { children: state.doc.rootFields },
+		rootField: { children: state.doc.rootFields } as Field,
 		fields:    state.doc.fields,
 	}),
-	dispatch => ({
+	( dispatch: (action: Action) => void ): Partial<WrappedFormulaEditorProps> => ({
 		onPathClick:  (path: string[]) => dispatch( setPath( path )),
 		onCreateNode: (fieldId: number) => dispatch( addNode( fieldId, 'ADD' )),
 	}),

--- a/src/components/Editor/FormulaEditor/index.tsx
+++ b/src/components/Editor/FormulaEditor/index.tsx
@@ -41,12 +41,7 @@ const fieldAtPath = ( path: string[], rootField: Field, fields: FieldMap ) => pa
 
 class FormulaEditor extends React.PureComponent<WrappedFormulaEditorProps, {}> {
 	public render() {
-		const fields = this.props.fields;
-		const rootField = this.props.rootField;
-		const path = this.props.path || [];
-		const onPathClick = this.props.onPathClick || (() => { /* Ignore click */ });
-		const onCreateNode = this.props.onCreateNode || (() => { /* Ignore node creation */ });
-
+		const { fields, rootField, path, onPathClick, onCreateNode } = this.props;
 		const field = fieldAtPath( path, rootField, fields );
 
 		return <div id="node-editor">
@@ -68,7 +63,7 @@ class FormulaEditor extends React.PureComponent<WrappedFormulaEditorProps, {}> {
 	}
 }
 
-const ConnectedNodeEditor = connect<{}, {}, WrappedFormulaEditorProps>(
+const ConnectedNodeEditor = connect<{}, {}, FormulaEditorProps>(
 	state => ({
 		path:      state.path,
 		rootField: { children: state.doc.rootFields },

--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -2,13 +2,18 @@ import * as React from 'react';
 
 import './Dropdown.less';
 
+export interface DropdownItem {
+	value: any;
+	text: string;
+}
+
 export interface DropdownProps extends React.Props<Dropdown> {
-	items: any[];
-	selection: any;
+	items: DropdownItem[];
+	selection: DropdownItem;
 	open: boolean;
-	onOpen: (item: any) => void;
-	onClose: (item: any) => void;
-	onSelect: (item: any) => void;
+	onOpen: (item: React.MouseEvent<HTMLButtonElement>) => void;
+	onClose: (item: React.MouseEvent<HTMLButtonElement>) => void;
+	onSelect: (item: DropdownItem) => void;
 }
 
 export class Dropdown extends React.Component<DropdownProps, {}> {

--- a/src/components/common/FAB.tsx
+++ b/src/components/common/FAB.tsx
@@ -4,7 +4,7 @@ import './FAB.less';
 
 export interface FABProps extends React.Props<FAB> {
 	icon: string;
-	onClick: (item: any) => void;
+	onClick: (item: React.MouseEvent<HTMLButtonElement>) => void;
 }
 
 export class FAB extends React.Component<FABProps, {}> {

--- a/src/components/common/Tree.tsx
+++ b/src/components/common/Tree.tsx
@@ -66,7 +66,7 @@ class TreeItem extends React.Component<TreeItemProps, {}> {
 					{ onCreateButtons( item ) }
 				</a>
 				{ !!children.length && <ul> {
-					children.map( (childItem: any) => <TreeItem
+					children.map( ( childItem ) => <TreeItem
 						key={ childItem.id }
 						item={ childItem }
 						onCreateButtons={ onCreateButtons }

--- a/src/components/common/Tree.tsx
+++ b/src/components/common/Tree.tsx
@@ -1,20 +1,21 @@
-import { Id } from 'data/shared';
 import * as React from 'react';
+
+import { Id } from 'data/shared';
 
 import './Tree.less';
 
 export interface TreeItemData {
-	id: any;
+	id: number;
 	path: string[];
 	children: TreeItemData[];
 	expanded: boolean;
 }
 
 export interface TreeProps extends React.Props<Tree> {
-	items: any[];
-	onCreateButtons?: (item?: any) => void;
-	onExpandItem?: (item?: any) => void;
-	onCollapseItem?: (item?: any) => void;
+	items: TreeItemData[];
+	onCreateButtons?: (item: TreeItemData) => void;
+	onExpandItem?: (item: TreeItemData) => void;
+	onCollapseItem?: (item: TreeItemData) => void;
 }
 
 export class Tree extends React.Component<TreeProps, {}> {
@@ -39,10 +40,10 @@ export class Tree extends React.Component<TreeProps, {}> {
 }
 
 interface TreeItemProps extends React.Props<TreeItem> {
-	item: any;
-	onCreateButtons: (item: any) => void;
-	onExpand: (item: any) => void;
-	onCollapse: (item: any) => void;
+	item: TreeItemData;
+	onCreateButtons: (item: TreeItemData) => void;
+	onExpand: (item: TreeItemData) => void;
+	onCollapse: (item: TreeItemData) => void;
 }
 
 class TreeItem extends React.Component<TreeItemProps, {}> {

--- a/src/data/doc.ts
+++ b/src/data/doc.ts
@@ -92,7 +92,7 @@ export interface DocUI {
 	expandedFields: Set<number>;
 }
 
-export const DocFromJSON = ( json: JSON.DocJSON ): Doc => {
+export const docFromJSON = ( json: JSON.DocJSON ): Doc => {
 	// This can't be done inline because it recurses into itself
 	const flattenFields = ( fields: JSON.FieldJSON[] ): JSON.FieldJSON[] => {
 		return fields.reduce(( acc, field ) => [

--- a/src/data/fxn.ts
+++ b/src/data/fxn.ts
@@ -2,7 +2,7 @@ export interface Fxn {
 	name: string;
 	inputs: string[];
 	output: string;
-	exec: (...params: number[]) => number;
+	exec: (...params: Array<number | string>) => number | string;
 }
 
 export const ADD: Fxn = {

--- a/src/state/reducers.ts
+++ b/src/state/reducers.ts
@@ -11,6 +11,13 @@ import { reducer as reduceExpandField   } from './expandField';
 import { reducer as reduceMoveNode      } from './moveNode';
 import { reducer as reduceSetPath       } from './setPath';
 
+export interface State {
+	doc: Doc;
+	path: string[];
+	ui: DocUI;
+}
+
+
 const exampleDoc = require<DocJSON>('data/exampleDoc.json');
 
 // ==============================================================================
@@ -60,7 +67,7 @@ const reduceUi: Reducer<DocUI> = combineReducers( {
 // ------------------------------------------------------------------------------
 // ------------------------------------------------------------------------------
 
-export default combineReducers( {
+export default combineReducers<State>( {
 	doc:  reduceDoc,
 	path: reducePath,
 	ui:   reduceUi,

--- a/src/state/reducers.ts
+++ b/src/state/reducers.ts
@@ -1,6 +1,6 @@
 import { combineReducers, Reducer } from 'redux';
 
-import Doc, { DocFromJSON, DocUI, NodeMap } from 'data/doc';
+import Doc, { docFromJSON, DocUI, NodeMap } from 'data/doc';
 import DocJSON from 'data/docJson';
 
 import Action from './action';
@@ -15,7 +15,7 @@ const exampleDoc = require<DocJSON>('data/exampleDoc.json');
 
 // ==============================================================================
 
-const reducePath = ( state = [], action: Action ) => reduceSetPath( state, action );
+const reducePath = ( state: string[] = [], action: Action ) => reduceSetPath( state, action );
 
 // ------------------------------------------------------------------------------
 // ------------------------------------------------------------------------------
@@ -29,7 +29,7 @@ const reduceNodes = ( state: NodeMap = new Map(), action: Action ) => [
 
 // ------------------------------------------------------------------------------
 
-const reduceDoc = ( state = DocFromJSON( exampleDoc ), action: Action ) => [
+const reduceDoc = ( state = docFromJSON( exampleDoc ), action: Action ) => [
 	(localState: any) => ({
 		...localState,
 		nodes: reduceNodes( localState.nodes, action ),


### PR DESCRIPTION
Some new type annotations and an `.editorconfig`. If you don't want the latter I'll rebase the PR so it doesn't include it, but it makes cross-platform/editor development much easier. All the `.editorconfig` settings match their respective `tslint` values.
